### PR TITLE
Fixed linking to external C code.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,10 +63,12 @@ Description:
   claim that Thomas Bayes did, but copy code that is compatible with our GPL 3 
   licence, fully acknowledging the authorship of the original code.
 Imports: 
-  Rcpp (>= 1.1.0)
+    GIGrvg,
+    Rcpp (>= 1.1.0)
 LinkingTo: 
-  Rcpp, 
-  RcppArmadillo
+  Rcpp,
+  RcppArmadillo,
+  GIGrvg
 Suggests: 
   tinytest
 URL: https://bsvars.org/StealLikeBayes/

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,3 +1,5 @@
 
+GIGRVG_SO = $(shell "${R_HOME}/bin/Rscript" -e "cat(system.file('libs', 'GIGrvg.so', package='GIGrvg'))")
+
 PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS)
-PKG_LIBS = $(SHLIB_OPENMP_CXXFLAGS) $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
+PKG_LIBS = $(SHLIB_OPENMP_CXXFLAGS) $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) $(GIGRVG_SO)

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,3 +1,5 @@
 
+GIGRVG_DLL = $(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript" -e "cat(system.file('libs', package='GIGrvg'))")
+
 PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS)
-PKG_LIBS = $(SHLIB_OPENMP_CXXFLAGS) $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
+PKG_LIBS = $(SHLIB_OPENMP_CXXFLAGS) $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) -L"$(GIGRVG_DLL)$(R_ARCH)" -lGIGrvg

--- a/src/sample_variances_normal_gamma.cpp
+++ b/src/sample_variances_normal_gamma.cpp
@@ -1,22 +1,7 @@
-
-#include <RcppArmadillo.h>
+#include "sample_variances_normal_gamma.h"
 
 using namespace arma;
 using namespace Rcpp;
-
-
-
-
-/* This function was stolen by Shelly Xie from bayesianVARs package by Luis Gruber and Gregor Kastner
- *  on 19 November 2025 and then rewritten.
- */
-double do_rgig(double lambda, double chi, double psi) {
-  
-  SEXP (*fun)(int, double, double, double) = NULL;
-  if (!fun) fun = (SEXP(*)(int, double, double, double)) R_GetCCallable("GIGrvg", "do_rgig");
-  
-  return as<double>(fun(1, lambda, chi, psi));
-}
 
 
 /* This function was stolen by Shelly Xie from bayesianVARs package by Luis Gruber and Gregor Kastner
@@ -34,7 +19,7 @@ arma::vec sample_variances_normal_gamma(
     const double varrho0, 
     const double varrho1, 
     const bool hyper, 
-    const double tol = 1e-6
+    const double tol
 ){
   const int N = x.n_elem;
   vec V_i(N);
@@ -46,7 +31,7 @@ arma::vec sample_variances_normal_gamma(
   
   arma::uvec::iterator it;
   for(it = ind.begin(); it != ind.end(); ++it){
-    theta_tilde(*it) = do_rgig(a-0.5, x(*it)*x(*it), a/zeta);
+    theta_tilde(*it) = REAL(do_rgig(1, a-0.5, x(*it)*x(*it), a/zeta))[0];
     if(hyper){
       for(int i=0; i<gridlength; ++i){
         logprobs(i) += R::dgamma(theta_tilde(*it),a_vec(i), 2*zeta/a_vec(i), true); // scale!!!

--- a/src/sample_variances_normal_gamma.h
+++ b/src/sample_variances_normal_gamma.h
@@ -4,9 +4,10 @@
 
 #include <RcppArmadillo.h>
 
-double do_rgig(double lambda, double chi, double psi);
-  
-  
+extern "C" {
+  #include <GIGrvg.h>
+}
+
 arma::vec sample_variances_normal_gamma(
     const arma::vec x, 
     arma::vec& theta_tilde,


### PR DESCRIPTION
Sorry Shelly for stealing your stolen job.

I managed to fix the external C code linking for my machine (Ubuntu, some intel processor).

For future reference, *in my opinion*, you should require:
1. All `#include` statements in the `module.h` file, and only `#include "module.h"` in the `.cpp` file. That way it's easier to maintain and check the dependencies for new PRs.
2. If a contribution links to an external package, you need to add a line `Makevars` and `Makevars.win`.

Notable things:
* For linking to C, I had to do this (I did it in the header):
```cpp
#include <RcppArmadillo.h>

extern "C" {
  #include <GIGrvg.h>
}
```

Also, I added some `Imports` and `LinkingTo` lines to the `DESCRIPTION`. 